### PR TITLE
Fix set user quota

### DIFF
--- a/plugins/modules/irods_user_quota.py
+++ b/plugins/modules/irods_user_quota.py
@@ -86,7 +86,7 @@ def get_quotas(module):
 
     fmt = ':'.join(['%s'] * len(_QUOTA_FIELDS))
 
-    where = ['QUOTA_USER_TYPE <> \'rodsgroup\'']
+    where = []
 
     if (module.params['zone'] is not None):
         where += ['QUOTA_USER_ZONE = \'%s\'' % module.params['zone']]


### PR DESCRIPTION
Bonjour,

Ceci est ma première PR, je m'excuse d'avance si je n'ai pas fait quelque chose correctement ou si j'ai oublié quelque chose.

Quand j'ai tenté de définir les quota des groupes via set_user_quota.py (qui possède des fonctions permettant de changer le quota des utilisateurs de type rodsgroup), cela produisait une erreur. Je propose donc un groupe de trois modifications, toutes faites dans la fonction « get_quotas(module) » :

### Formattage des arguments de la commande iquest

La commande iquest renvoie une erreur permettant de voir que ce qui est sensé être le deuxième filtre est mal joint par des « and » : « andQandUandOandTandAand_andUandSandEandRand_andZandOandNandEand [...] ». Deux modifications pour résoudre ça : ajouter un tableau de strings plutôt qu'une string au tableau « where » afin d'éviter que chaque caractère soit joint plus tard, et ajouter des espaces dans la chaîne de caractères du « and » servant à joindre les chaînes du tableau.

### Cas où aucun utilisater n'est renvoyé

Quand iquest ne renvoie aucun utilisateur, le code de retour est 1, ce qui fait que la commande est traitée comme ayant échoué. Pour corriger ça, ajouter la vérification que la chaîne « CAT_NO_ROWS_FOUND » n'est pas présente dans la sortie. J'ai également ajouté des détails au message d'erreur renvoyant plus d'informations sur les paramètres de la commande.

### Traitement des utilisateurs représentant des groupes

Un commit précédent a ajouté la possibilité de gérer les groupes d'utilisateurs représentés par des utilisateurs de type « rodsgroup », mais ceux-ci sont filtrés du résultat de « get_quotas ». Initialiser la variable « where » avec une liste vide permet de retirer le filtre, les utilisateurs de type « rodsgroup » étant séparés des autres par la fonction « main ». De plus, « rodsgroup » n'est pas utilisé ailleurs dans le fichier, le changement de la sortie ne devrait donc pas changer le comportement du module ailleurs.