### PR TITLE
Fix error on empty input “names” list (not null) for module “irods_user”

### DIFF
--- a/plugins/modules/irods_user.py
+++ b/plugins/modules/irods_user.py
@@ -127,8 +127,13 @@ def params_to_users(params):
     for k, v in _USER_PARAM_FIELDS.items():
         if params[k] is not None:
             skel[v] = params[k]
-
-    names = params['names'] or [params['name']]
+ 
+    if params['names'] is not None:
+        names = params['names']
+    elif params['name'] is not None:
+        names = [params['name']]
+    else:
+        raise Exception("No username given (Should not happen according to module logic)")
 
     users = {}
 


### PR DESCRIPTION
Bonjour,

### Observation

Le module `irods_user` levait une erreur quand l'entrée `names`, sensée contenir une liste de noms d'utilisateurs desquels il doit s'assurer la présence ou l'absence, est vide (et non nulle).

### Explication

La ligne `names = params['names'] or [params['name']]` de la fonction `params_to_users(params)` fait que `names` contient une liste avec un élément `None` quand l'entrée `names` du module est utilisée avec une liste vide (car une liste vide est conditionnellement évaluée comme fausse en Python). Cet utilisateur `None` se retrouve ensuite dans la liste des utilisateurs `wanted` et fait que la ligne `user_name += '#' + user['USER_ZONE']` de la fonction `add_user(module, user)` lève une erreur (car user_name est `None` au lieu d'être une chaine de caractères).

### Correction

Remplacer  `names = params['names'] or [params['name']]` par des blocs `if` vérifiant si les argments sont `None` plutôt que faux.