### PR TITLE
Fix: Key was inexistant if user had no previous quota set

### DIFF
--- a/plugins/modules/irods_user_quota.py
+++ b/plugins/modules/irods_user_quota.py
@@ -243,11 +243,7 @@ def main():
         module.exit_json(**result)
 
     for k, v in user_quotas.items():
-        if k in got_users:
-            w = got_users[k]
-        else:
-            w = {}
-        if v != w:
+        if v != got_users.get(k):
             result['operations'].append(qprint(v, 'u'))
             set_user_quota(module,
                            v['QUOTA_USER_NAME'],
@@ -257,11 +253,7 @@ def main():
             
 
     for k, v in group_quotas.items():
-        if k in got_groups:
-            w = got_groups[k]
-        else:
-            w = {}
-        if v != w:
+        if v != got_groups.get(k):
             result['operations'].append(qprint(v, 'g'))
             set_group_quota(module,
                            v['QUOTA_USER_NAME'],


### PR DESCRIPTION
Bonjour,

### Observation

Quand un utilisateur ou groupe n'a pas de quota défini, le module `irods_user_quota.py` renvoie une erreur en tantant de chercher dans `got_users` (dictionnaire contenant les utilisateurs renvoyés par `get_quotas(module)` qui sont également dans les utilisateurs passés en paramètre du module) les clés de `user_quotas` (dictionnaire contenant les utilisateurs passés en paramètre du module).

### Explication

La requête passée par `iquest` dans la fonction `get_quotas(module)` ne renvoie pas les utilisateurs existant mais n'ayant pas de quota. Ceux-ci ne se retrouvent donc pas dans le dictionnaire `got_users`.

### Correction

Vérifier que la clé existe dans `got_users` avant d'en chercher la valeur, définir la variable `w` comme le dictionnaire vide si la clé n'y existe pas. `w` n'est pas réutilisée après avoir vérifier qu'un changement est à effectuer, cela n'impacte donc pas le reste du code.

### Note

Les mêmes problèmes et corrections s'appliquent aux variables gérant les utilisateurs représentant des groupes (comme `got_groups`).