### PR TITLE
Fix S3 plugin package version to follow irods_version variable

### DIFF
--- a/roles/irods/vars/Debian.yml
+++ b/roles/irods/vars/Debian.yml
@@ -19,7 +19,7 @@ irods_icommands_pkgname_short: "irods-icommands"
 # yamllint disable-line rule:line-length
 irods_database_pkgname: "irods-database-plugin-postgres{{ irods_package_extension }}"
 irods_database_pkgname_short: "irods-database-plugin-postgres"
-#FIXME automatically determine the major version A.B but without the minor version
-irods_s3_plugin_pkgname: "irods-resource-plugin-s3=5.0*"
+# FIXME: pin to major.minor only (e.g. =4.3*) to allow patch-level updates within an ABI-compatible cycle
+irods_s3_plugin_pkgname: "irods-resource-plugin-s3{{ irods_package_extension }}"
 irods_s3_plugin_pkgname_short: "irods-resource-plugin-s3"
 


### PR DESCRIPTION
The S3 plugin package name was hardcoded to `5.0*`, which breaks installations pinned to iRODS 4.3.x. Aligned on `irods_package_extension` like all other iRODS packages. The plugin version now follows the same pinning strategy.

## Change

`roles/irods/vars/Debian.yml`:
- Before: `irods-resource-plugin-s3=5.0*`
- After: `irods-resource-plugin-s3{{ irods_package_extension }}`

## Testing

Tested on Debian 12 + iRODS 4.3.5, via Ansible + Molecule.

## Scope

Only `roles/irods/vars/Debian.yml` is updated. If the same hardcoding exists in `vars/Ubuntu.yml` or `vars/RedHat*.yml`, it would need the same treatment. Not tested on my side.