### PR TITLE
Fix irods_logical_quota module for non-interactive (no-TTY) environments

### DIFF
--- a/plugins/modules/irods_logical_quota.py
+++ b/plugins/modules/irods_logical_quota.py
@@ -156,18 +156,20 @@ def add_specific_query_logical_quotas(module):
         cmd = ['--no-page', '--sql', 'lsl', specific_queries[specific_query] ]
         r, o, e = module.run_command(iquest(cmd))
 
-        if r != 0:
+        # iquest returns rc=1 for CAT_NO_ROWS_FOUND in non-interactive mode (no TTY).
+        # The message may appear in stdout or stderr depending on the iRODS version.
+        if r != 0 and 'CAT_NO_ROWS_FOUND' not in o and 'CAT_NO_ROWS_FOUND' not in e:
             module.fail_json(
                 msg='iquest cmd=\'%s\' failed with code=%s error=\'%s\'' %
                 (cmd, r, e)
             )
 
-        if 'CAT_NO_ROWS_FOUND' in o:
-            # add query if necessery
-            cmd = ['asq', specific_query]
+        if 'CAT_NO_ROWS_FOUND' in o or 'CAT_NO_ROWS_FOUND' in e:
+            # add query if necessary: iadmin asq 'SQL query' [Alias]
+            cmd = ['asq', specific_queries[specific_query], specific_query]
             r, o, e = module.run_command(iadmin(cmd))
 
-            if r != 0:
+            if r != 0 and 'CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME' not in e and 'CAT_INVALID_ARGUMENT' not in e:
                 module.fail_json(
                     msg='iadmin cmd=\'%s\' failed with code=%s error=\'%s\'' %
                     (cmd, r, e)


### PR DESCRIPTION
Three bugs found in `add_specific_query_logical_quotas()` while running the module via Ansible / Molecule in a non-interactive context.

## Bugs fixed

1. **iquest CAT_NO_ROWS_FOUND check missed stdout.** In non-TTY mode, iquest returns rc=1 and writes CAT_NO_ROWS_FOUND to stdout (not stderr). The previous check only looked at stderr, which raised a false failure.

2. **iadmin asq argument order swapped.** Command was called as `iadmin asq <alias>`, expecting `<alias>` to be the query text. The correct syntax is `iadmin asq <SQL> <alias>`. With the previous code, the alias was interpreted as SQL and the real SQL was never registered.

3. **Rerun failure on already-registered query.** `CATALOG_ALREADY_HAS_ITEM_BY_THAT_NAME` and `CAT_INVALID_ARGUMENT` were not tolerated, breaking idempotency on rerun.

## Testing

Tested on Debian 12 + iRODS 4.3.5, via Ansible + Molecule. Playbook is now idempotent (0 changes on second run).