### PR TITLE
Ajout service systemd pour irods 4.3.2

### DIFF
--- a/roles/irods/tasks/irods.yml
+++ b/roles/irods/tasks/irods.yml
@@ -126,7 +126,7 @@
     mode: "0644"
     owner: root
     group: root
-  when: irods_config_schema_version == "v5"
+  when: (irods_config_schema_version == "v5") or (irods_config_schema_version == "v4")
 
 - name: Set correct acPreconnect rule for server to be able to connect to zone
   ansible.builtin.lineinfile:

--- a/roles/irods/templates/v4/irods.service.j2
+++ b/roles/irods/templates/v4/irods.service.j2
@@ -1,0 +1,25 @@
+[Unit]
+Description=iRODS
+After=network.target local-fs.target
+Requires=network.target
+
+[Service]
+Type=forking
+
+ExecStart=/var/lib/irods/irodsctl start
+ExecReload=/var/lib/irods/irodsctl restart
+ExecStop=/var/lib/irods/irodsctl stop
+
+Restart=on-failure
+RestartSec=5s
+
+User=irods
+Group=irods
+
+WorkingDirectory=/var/lib/irods
+Environment=HOME=/var/lib/irods
+
+LimitNOFILE=1048576
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Ajout de la définition d'un service systemd pour irods 4.3.2 en remplacement du script sysv init